### PR TITLE
#3 도커 컨테이너로 프로메테우스 서버 설정 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ repositories {
 }
 
 dependencies {
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.8"
+
+services:
+  prometheus:
+    image: iamabear09/prometheus
+    build: ./prometheus
+    ports:
+      - "9090:9090"

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -1,0 +1,2 @@
+FROM prom/prometheus
+COPY ./prometheus.yml /etc/prometheus/prometheus.yml

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,21 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+alerting:
+  alertmanagers:
+    - static_configs:
+      - targets:
+      # - alertmanager:9093
+
+rule_files:
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "spring-actuator"
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 1s
+    static_configs:
+    - targets: ["host.docker.internal:8080"]


### PR DESCRIPTION
## 프로메테우스 설정 방법

- bind mount 를 통해서 host의 프로메테우스 설정 폴더가 컨테이너의 프로메테우스의 설정폴더가 되도록 설정
- 프로메테우스 기본 이미지에 나의 설정 파일을 COPY해서 새로운 이미지를 빌드할 수 있다. 

## 프로메테우스 데이터 보관 방법

- 볼륨을 사용해서 데이터를 보관한다.